### PR TITLE
Use configured API url instead of hardcoded one

### DIFF
--- a/src/Api/Utils.purs
+++ b/src/Api/Utils.purs
@@ -1,0 +1,74 @@
+module Api.Utils
+       (withUser
+       , withAuthUser
+       , withAuthUser_
+       ) where
+
+import Prelude
+
+import Affjax (Request)
+import Api.Request (AuthUser, BaseURL, runRequest, username)
+import Capability.Authenticate (class Authenticate, deleteAuth, readAuth)
+import Capability.LogMessages (class LogMessages, logError)
+import Capability.Navigate (class Navigate, logout, navigate)
+import Control.Monad.Reader (class MonadAsk, ask)
+import Data.Argonaut (Json)
+import Data.Bifoldable (bitraverse_)
+import Data.Bitraversable (ltraverse)
+import Data.Either (Either(..))
+import Data.Route as Route
+import Data.Username (Username)
+import Effect.Aff.Class (class MonadAff)
+
+-- Helper functions that leverages several of our capabilities together to help
+-- run requests that require authentication.
+
+withUser
+  :: forall m e a
+   . MonadAff m 
+  => LogMessages m 
+  => Navigate m 
+  => MonadAsk { rootUrl :: BaseURL | e } m
+  => Authenticate m
+  => (Username -> Json -> Either String a)
+  -> (BaseURL -> Request Json)
+  -> m (Either String a)
+withUser decode req =
+  readAuth >>= case _ of
+    Left err -> logError err *> pure (Left err)
+    Right au -> do
+      { rootUrl } <- ask
+      runRequest (decode (username au)) $ req rootUrl
+
+withAuthUser 
+  :: forall m a e
+   . MonadAff m 
+  => LogMessages m
+  => Navigate m 
+  => MonadAsk { rootUrl :: BaseURL | e } m
+  => Authenticate m 
+  => (Username -> Json -> Either String a)
+  -> (AuthUser -> BaseURL -> Request Json)
+  -> m (Either String a)
+withAuthUser decode req =
+  readAuth >>= case _ of
+    Left err -> logError err *> deleteAuth *> navigate Route.Login *> pure (Left err) 
+    Right au -> do
+      { rootUrl } <- ask
+      res <- runRequest (decode (username au)) (req au rootUrl)
+      void $ ltraverse (\e -> logError e *> logout) res
+      pure res
+
+withAuthUser_ 
+  :: forall m e
+   . MonadAff m 
+  => LogMessages m 
+  => Navigate m 
+  => MonadAsk { rootUrl :: BaseURL | e } m
+  => Authenticate m 
+  => (AuthUser -> BaseURL -> Request Json) 
+  -> m Unit 
+withAuthUser_ req =
+  readAuth >>= bitraverse_
+    (\e -> logError e *> logout)
+    (\au -> ask >>= runRequest pure <<< req au <<< _.rootUrl)

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -2,7 +2,7 @@ module Main where
 
 import Prelude
 
-import Api.Request (URL(..))
+import Api.Request (BaseURL(..))
 import AppM (Env, LogLevel(..), runAppM)
 import Component.Router as Router
 import Data.Maybe (Maybe(..))
@@ -24,7 +24,7 @@ main = HA.runHalogenAff do
   let environment :: Env
       environment = 
         { logLevel: Dev 
-        , rootUrl: URL "https://conduit.productionready.io/"
+        , rootUrl: BaseURL "https://conduit.productionready.io/"
         }
 
       router :: H.Component HH.HTML Router.Query Unit Void Aff

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -2,6 +2,7 @@ module Main where
 
 import Prelude
 
+import Api.Request (URL(..))
 import AppM (Env, LogLevel(..), runAppM)
 import Component.Router as Router
 import Data.Maybe (Maybe(..))
@@ -23,7 +24,7 @@ main = HA.runHalogenAff do
   let environment :: Env
       environment = 
         { logLevel: Dev 
-        , rootUrl: "https://conduit.productionready.io/"
+        , rootUrl: URL "https://conduit.productionready.io/"
         }
 
       router :: H.Component HH.HTML Router.Query Unit Void Aff


### PR DESCRIPTION
* Adds a URL newtype over String

* Add URL parameter in Request functions get, post, etc...

* Wire the rootUrl from Env in AppM instances