### PR TITLE
Adapt profile json-decoding

### DIFF
--- a/src/Api/Request.purs
+++ b/src/Api/Request.purs
@@ -30,7 +30,7 @@ import Affjax.RequestHeader (RequestHeader(..))
 import Affjax.ResponseFormat as RF
 import Conduit.Api.Endpoint (Endpoint(..), endpointCodec)
 import Conduit.Data.Email (Email)
-import Conduit.Data.Profile (Profile)
+import Conduit.Data.Profile (Profile, decodeProfile)
 import Conduit.Data.Username (Username)
 import Data.Argonaut.Core (Json)
 import Data.Argonaut.Decode (decodeJson, (.:))
@@ -260,7 +260,7 @@ requestUser baseUrl opts = do
 decodeAuthProfile :: Json -> Either String (Tuple Token Profile)
 decodeAuthProfile json = do
   str <- decodeJson =<< (_ .: "token") =<< decodeJson json
-  prof <- decodeJson json
+  prof <- decodeProfile json
   pure $ Tuple (Token str) prof
 
 -- | The following functions deal with writing, reading, and deleting tokens in local storage at a 

--- a/src/Api/Utils.purs
+++ b/src/Api/Utils.purs
@@ -91,7 +91,10 @@ authenticate req fields = do
 -- | decodeProfile = decodeAt "user"
 -- | ```
 decodeAt :: forall a. DecodeJson a => String -> Json -> Either String a
-decodeAt key = decodeJson <=< (_ .: key) <=< decodeJson
+decodeAt = decodeWithAt decodeJson
+
+decodeWithAt :: forall a. DecodeJson a => (Json -> Either String a) -> String -> Json -> Either String a
+decodeWithAt decoder key = decoder <=< (_ .: key) <=< decodeJson
 
 -- | This small utility decodes JSON and logs any failures that occurred, returning the parsed 
 -- | value only if decoding succeeded. This utility makes it easy to abstract the mechanices of 

--- a/src/AppM.purs
+++ b/src/AppM.purs
@@ -19,7 +19,7 @@ import Prelude
 import Conduit.Api.Endpoint (Endpoint(..), noArticleParams)
 import Conduit.Api.Request (BaseURL, RequestMethod(..))
 import Conduit.Api.Request as Request
-import Conduit.Api.Utils (authenticate, decode, decodeAt, decodeWithUser, mkAuthRequest, mkRequest)
+import Conduit.Api.Utils (authenticate, decode, decodeAt, decodeWithAt, decodeWithUser, mkAuthRequest, mkRequest)
 import Conduit.Capability.LogMessages (class LogMessages)
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Now (class Now)
@@ -30,7 +30,7 @@ import Conduit.Capability.Resource.User (class ManageUser)
 import Conduit.Data.Article (decodeArticle, decodeArticles)
 import Conduit.Data.Comment (decodeComments)
 import Conduit.Data.Log as Log
-import Conduit.Data.Profile (Profile, decodeAuthor)
+import Conduit.Data.Profile (Profile, decodeAuthor, decodeProfileWithEmail)
 import Conduit.Data.Route as Route
 import Control.Monad.Reader.Trans (class MonadAsk, ReaderT, ask, asks, runReaderT)
 import Data.Argonaut.Encode (encodeJson)
@@ -223,7 +223,7 @@ instance manageUserAppM :: ManageUser AppM where
 
   getCurrentUser = 
     mkAuthRequest { endpoint: User, method: Get }
-      >>= decode (decodeAt "user")
+      >>= decode (decodeWithAt decodeProfileWithEmail "user")
 
   getAuthor username = 
     mkRequest { endpoint: Profiles username, method: Get }


### PR DESCRIPTION
* Some Conduit backend implementations refrain from including undetermined
field values as key/value entries in JSON responses to clients.
* The changes included handle such absent key/value rows.