### PR TITLE
Global state with subscribed components

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,8 @@
     "purescript-precise-datetime": "^5.1.1",
     "purescript-typelevel-prelude": "^4.0.0",
     "purescript-argonaut-codecs": "^6.0.1",
-    "purescript-argonaut-core": "^5.0.0"
+    "purescript-argonaut-core": "^5.0.0",
+    "purescript-aff-bus": "^4.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/src/AppM.purs
+++ b/src/AppM.purs
@@ -36,6 +36,7 @@ import Control.Monad.Reader.Trans (class MonadAsk, ReaderT, ask, asks, runReader
 import Data.Argonaut.Encode (encodeJson)
 import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff)
+import Effect.Aff.Bus (BusRW)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Console as Console
@@ -81,9 +82,9 @@ type Env =
   { logLevel :: LogLevel 
   , baseUrl :: BaseURL
   , currentUser :: Ref (Maybe Profile)
+  , userBus :: BusRW (Maybe Profile)
   }
 
--- | A flag to control the environment for logging messages.
 data LogLevel = Dev | Prod
 
 derive instance eqLogLevel :: Eq LogLevel

--- a/src/AppM.purs
+++ b/src/AppM.purs
@@ -37,7 +37,8 @@ import Data.Argonaut.Encode (encodeJson)
 import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff)
 import Effect.Aff.Bus (BusRW)
-import Effect.Aff.Class (class MonadAff)
+import Effect.Aff.Bus as Bus
+import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Console as Console
 import Effect.Now as Now
@@ -206,8 +207,12 @@ instance navigateAppM :: Navigate AppM where
     liftEffect <<< setHash <<< print Route.routeCodec 
 
   logout = do
-    liftEffect <<< Ref.write Nothing =<< asks _.currentUser
-    liftEffect Request.removeToken 
+    { currentUser, userBus } <- ask
+    liftEffect do 
+      Ref.write Nothing currentUser
+      Request.removeToken 
+    liftAff do
+      Bus.write Nothing userBus
     navigate Route.Home
 
 -- | Our first resource class describes what operations we have available to manage users. Logging 

--- a/src/AppM.purs
+++ b/src/AppM.purs
@@ -17,7 +17,7 @@ module Conduit.AppM where
 import Prelude
 
 import Conduit.Api.Endpoint (Endpoint(..), noArticleParams)
-import Conduit.Api.Request (BaseURL, RequestMethod(..))
+import Conduit.Api.Request (RequestMethod(..))
 import Conduit.Api.Request as Request
 import Conduit.Api.Utils (authenticate, decode, decodeAt, decodeWithAt, decodeWithUser, mkAuthRequest, mkRequest)
 import Conduit.Capability.LogMessages (class LogMessages)
@@ -30,19 +30,18 @@ import Conduit.Capability.Resource.User (class ManageUser)
 import Conduit.Data.Article (decodeArticle, decodeArticles)
 import Conduit.Data.Comment (decodeComments)
 import Conduit.Data.Log as Log
-import Conduit.Data.Profile (Profile, decodeAuthor, decodeProfileWithEmail)
+import Conduit.Data.Profile (decodeAuthor, decodeProfileWithEmail)
 import Conduit.Data.Route as Route
+import Conduit.Env (Env, LogLevel(..))
 import Control.Monad.Reader.Trans (class MonadAsk, ReaderT, ask, asks, runReaderT)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff)
-import Effect.Aff.Bus (BusRW)
 import Effect.Aff.Bus as Bus
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Console as Console
 import Effect.Now as Now
-import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Routing.Duplex (print)
 import Routing.Hash (setHash)
@@ -64,38 +63,12 @@ import Type.Equality (class TypeEquals, from)
 -- | This module implements a monad that can run all the abstract capabilities we've defined. This 
 -- | is our production monad. We'll implement the monad first, and then we'll provide concrete 
 -- | instances for each of our abstract cayabilities.
-
--- | Let's start with some types necessary for the rest of the module.
 -- |
--- | Our app monad will provide a globally-accessible, read-only environment with three fields. 
--- | First, we'll use a `LogLevel` flag to indicate whether we'd like to log everything (`Dev`) or 
--- | only critical messages (`Prod`). Next, we'll maintain a configurable base URL. Finally, we'll 
--- | do something tricky: we'll maintain a mutable reference to the profile of the current user (if 
--- | there is one).
--- |
--- | The PureScript type system can enforce that our environment is read-only, but our use of a 
--- | mutable reference lets us implement a global mutable state anyway. That's because we can't 
--- | modify the reference, but we can modify the data it points to. This should be used sparingly!
--- |
--- | In a moment I'll describe how to make this information available (without passing it as an 
--- | argument) to any function running in `AppM`.
-type Env = 
-  { logLevel :: LogLevel 
-  , baseUrl :: BaseURL
-  , currentUser :: Ref (Maybe Profile)
-  , userBus :: BusRW (Maybe Profile)
-  }
-
-data LogLevel = Dev | Prod
-
-derive instance eqLogLevel :: Eq LogLevel
-derive instance ordLogLevel :: Ord LogLevel
-
 -- | Our application monad is going to combine the abilities of the `Aff` (asynchronous effects)
 -- | and `Reader` (read-only environment) monads, and then we'll add several more abilities by 
 -- | writing instances for our various capabilities.
 -- |
--- | The `Reader` monad allows us to access some data (`Env`, in our case, as defined above) using 
+-- | The `Reader` monad allows us to access some data (`Env`, in our case, as defined in `Env`) using 
 -- | the `ask` function, without having passed the data as an argument. It will help us avoid 
 -- | tediously threading commonly-used information throughout the application.
 -- |
@@ -207,7 +180,7 @@ instance navigateAppM :: Navigate AppM where
     liftEffect <<< setHash <<< print Route.routeCodec 
 
   logout = do
-    { currentUser, userBus } <- ask
+    { currentUser, userBus } <- asks _.userEnv
     liftEffect do 
       Ref.write Nothing currentUser
       Request.removeToken 

--- a/src/Component/Part/FavoriteButton.purs
+++ b/src/Component/Part/FavoriteButton.purs
@@ -43,7 +43,7 @@ favoriteButton
 favoriteButton buttonSize favoriteAct unfavoriteAct article =
   HH.button
     [ css $ "btn btn-sm " <> if article.favorited then "btn-primary" else "btn-outline-primary"
-    , HE.onClick \_ -> Just if article.favorited then favoriteAct else unfavoriteAct
+    , HE.onClick \_ -> Just if article.favorited then unfavoriteAct else favoriteAct
     ]
     [ HH.i 
         [ css "ion-heart" ]

--- a/src/Component/Router.purs
+++ b/src/Component/Router.purs
@@ -77,7 +77,11 @@ component
 component = H.mkComponent
   { initialState: \_ -> { route: Nothing, currentUser: Nothing } 
   , render
-  , eval: H.mkEval $ H.defaultEval { handleQuery = handleQuery }
+  , eval: H.mkEval $ H.defaultEval 
+      { handleQuery = handleQuery 
+      , handleAction = handleAction
+      , initialize = Just Initialize
+      }
   }
   where 
   handleAction :: Action -> H.HalogenM State Action ChildSlots Void m Unit
@@ -105,8 +109,9 @@ component = H.mkComponent
       when (route /= Just dest) do
         -- don't change routes if there is a logged-in user trying to access
         -- a route only meant to be accessible to a not-logged-in session
-        unless (isJust currentUser && dest `elem` [ Login, Register ]) do
-          H.modify_ _ { route = Just dest }
+        case (isJust currentUser && dest `elem` [ Login, Register ]) of
+          false -> H.modify_ _ { route = Just dest }
+          _ -> pure unit
       pure (Just a)
 
   -- Display the login page instead of the expected page if there is no current user; a simple 

--- a/src/Component/Router.purs
+++ b/src/Component/Router.purs
@@ -17,6 +17,7 @@ import Conduit.Capability.Resource.User (class ManageUser)
 import Conduit.Component.Utils (OpaqueSlot, busEventSource)
 import Conduit.Data.Profile (Profile)
 import Conduit.Data.Route (Route(..), routeCodec)
+import Conduit.Env (UserEnv)
 import Conduit.Page.Editor as Editor
 import Conduit.Page.Home as Home
 import Conduit.Page.Login as Login
@@ -25,14 +26,12 @@ import Conduit.Page.Profile as Profile
 import Conduit.Page.Register as Register
 import Conduit.Page.Settings as Settings
 import Conduit.Page.ViewArticle as ViewArticle
-import Control.Monad.Reader (class MonadAsk, ask)
+import Control.Monad.Reader (class MonadAsk, asks)
 import Data.Either (hush)
 import Data.Foldable (elem)
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.Symbol (SProxy(..))
-import Effect.Aff.Bus (BusRW)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Halogen (liftEffect)
 import Halogen as H
@@ -65,7 +64,7 @@ type ChildSlots =
 component
   :: forall m r
    . MonadAff m
-  => MonadAsk { currentUser :: Ref (Maybe Profile), userBus :: BusRW (Maybe Profile) | r } m
+  => MonadAsk { userEnv :: UserEnv | r } m
   => Now m
   => LogMessages m
   => Navigate m
@@ -89,7 +88,7 @@ component = H.mkComponent
     Initialize -> do
       -- first, we'll get the value of the current user and subscribe to updates any time the
       -- value changes
-      { currentUser, userBus } <- ask
+      { currentUser, userBus } <- asks _.userEnv
       _ <- H.subscribe (HandleUserBus <$> busEventSource userBus)
       mbProfile <- liftEffect (Ref.read currentUser) 
       H.modify_ _ { currentUser = mbProfile }

--- a/src/Component/Utils.purs
+++ b/src/Component/Utils.purs
@@ -3,45 +3,77 @@ module Conduit.Component.Utils where
 
 import Prelude
 
-import Conduit.Capability.Navigate (class Navigate, logout)
+import Conduit.Capability.Navigate (class Navigate)
 import Conduit.Data.Profile (Profile)
-import Control.Monad.Reader (class MonadAsk, asks)
+import Control.Monad.Reader (class MonadAsk, ask)
+import Control.Monad.Rec.Class (forever)
 import Data.Const (Const)
-import Data.Maybe (Maybe(..))
-import Effect.Class (class MonadEffect, liftEffect)
+import Data.Maybe (Maybe)
+import Effect.Aff (error, forkAff, killFiber)
+import Effect.Aff.Bus as Bus
+import Effect.Aff.Class (class MonadAff)
+import Effect.Class (liftEffect)
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Halogen as H
+import Halogen.Query.EventSource as ES
 
 -- | When a component has no queries or messages, it has no public interface and can be
 -- | considered an "opaque" component. The only way for a parent to interact with the component
 -- | is by sending input.
 type OpaqueSlot = H.Slot (Const Void) Void
 
--- | Several components verify that a current user exists and, if there is none in state, log the 
--- | user out and redirect to the home page. This way, an inadvertent route to the settings page, 
--- | for example, is protected at initialization.
-guardSession
-  :: forall m r
-   . MonadEffect m
-  => MonadAsk { currentUser :: Ref (Maybe Profile) | r } m
-  => Navigate m
-  => m (Maybe Profile)
-guardSession = do 
-  asks _.currentUser >>= (Ref.read >>> liftEffect) >>= case _ of
-    Nothing -> logout *> pure Nothing 
-    Just profile -> pure (Just profile)
+-- | Sometimes it's useful for a component to subscribe to a stream of incoming information. 
+-- | Halogen provides 'event sources' for this purpose. For example, you can send messages to
+-- | subscribers when key events occur on the global window, so multiple components subscribe to
+-- | and are notified about these events.
+-- |
+-- | At other times it's useful to subscribe to non-DOM events. The most common of these is when 
+-- | you have a global state with a piece of mutable data and multiple components need to stay in
+-- | sync about the current value of that data. Each time the data is changed, you can broadcast
+-- | the change to subscribed components so they always have the correct information.
+-- |
+-- | In our case, we'll use this to subscribe components to updates about the value of the current
+-- | user in global state.
+-- |
+-- | This helper function helps create an event source from a many-to-many bus. For example:
+-- | 
+-- | ```purescript
+-- | handleAction = case _ of 
+-- |   Initialize -> do
+-- |     { bus } <- ask
+-- |     subscribeWithAction HandleBus bus
+-- |   
+-- |   HandleBus busMessage -> do
+-- |     ...
+-- | ```
+subscribeWithAction
+  :: forall busMsg st act slots msg m r
+   . MonadAff m 
+  => (busMsg -> act) 
+  -> Bus.BusR' r busMsg 
+  -> H.HalogenM st act slots msg m Unit
+subscribeWithAction handler bus =
+  void $ H.subscribe $ ES.affEventSource \emitter -> do
+    fiber <- forkAff $ forever $ ES.emit emitter <<< handler =<< Bus.read bus
+    pure (ES.Finalizer (killFiber (error "Event source closed") fiber))
 
--- | Some components only reasonably need to mount if there is NO active session. This utility 
--- | redirects to the home page when there is an active session for a component like the 
--- | registration page.
-guardNoSession
-  :: forall m r
-   . MonadEffect m
-  => MonadAsk { currentUser :: Ref (Maybe Profile) | r } m
+-- | Some components need to retrieve the current value of the logged-in user from state and would
+-- | also like to subscribe to further updates at the same time. This helper function bundles that
+-- | behavior so you can both retrieve the value and subscribe to further changes at once.
+-- |
+-- | Note: It's not strictly necessary for any components in Conduit to subscribe to changes in the 
+-- | logged-in user, because that only happens at login / logout; at these points, components are
+-- | re-mounted anyway and will always be up-to-date with the latest state. Still, this is too 
+-- | useful a pattern to leave out altogether!
+loadUserEnv
+  :: forall st act slots msg m r
+   . MonadAff m
+  => MonadAsk { currentUser :: Ref (Maybe Profile), userBus :: Bus.BusRW (Maybe Profile) | r } m
   => Navigate m
-  => m Unit
-guardNoSession = do 
-  asks _.currentUser >>= (Ref.read >>> liftEffect) >>= case _ of
-    Nothing -> pure unit
-    Just _ -> logout *> pure unit
+  => (Maybe Profile -> act)
+  -> H.HalogenM st act slots msg m (Maybe Profile)
+loadUserEnv handler = do 
+  { currentUser, userBus } <- ask
+  subscribeWithAction handler userBus 
+  liftEffect $ Ref.read currentUser

--- a/src/Env.purs
+++ b/src/Env.purs
@@ -1,0 +1,55 @@
+-- | A global, read-only state containing information useful to most components in the application.
+-- | To represent mutable state, you can use a mutable reference stored in the immutable record. To
+-- | broadcast changes in mutable state (or to broadcast any other messages you'd like) to 
+-- | subscribed components, you can use a many-to-many bus.
+-- |
+-- | https://thomashoneyman.com/guides/real-world-halogen
+module Conduit.Env where
+
+import Prelude
+
+import Conduit.Api.Request (BaseURL)
+import Conduit.Data.Profile (Profile)
+import Data.Maybe (Maybe)
+import Effect.Aff.Bus (BusRW)
+import Effect.Ref (Ref)
+
+-- | Let's start with some types necessary for the rest of the module.
+-- |
+-- | Our app monad will provide a globally-accessible, read-only environment with a few fields. 
+-- | First, we'll use a `LogLevel` flag to indicate whether we'd like to log everything (`Dev`) or 
+-- | only critical messages (`Prod`). Next, we'll maintain a configurable base URL. Our `UserEnv`
+-- | will represent some mutable state holding the currently-logged-in user (if there is one).
+-- |
+-- | In the `AppM` module I demonstrate how to make this information available (without passing it 
+-- | as an argument) to any function running in `AppM`.
+type Env = 
+  { logLevel :: LogLevel 
+  , baseUrl :: BaseURL
+  , userEnv :: UserEnv
+  }
+
+data LogLevel = Dev | Prod
+
+derive instance eqLogLevel :: Eq LogLevel
+derive instance ordLogLevel :: Ord LogLevel
+
+-- | This type desribes a sub-section of our user environment. Having a section within the larger
+-- | record makes it easier to write constraints for components; you can, for example, require 
+-- | a monad supporting the environment { userEnv :: UserEnv | more } rather than having to list
+-- | all the individual fields in `UserEnv`.
+-- |
+-- | Our user environment needs mutable state, as the currently-logged-in user will change while
+-- | the application is running. How do you get mutable state from a read-only record?
+-- |
+-- | Use a mutable reference! The environment will be read-only, which means we cannot modify the 
+-- | reference, but we *can* modify the data it points to. Use this sparingly!
+-- | 
+-- | It's not enough just to have the mutable state, however; we also need to be able to notify
+-- | components when the value has changed, so that any local copies they have are always kept 
+-- | in sync. We'll do that with a bus. The bus will emit the new (maybe) profile any time it
+-- | changes to all subscribed components.
+type UserEnv =
+  { currentUser :: Ref (Maybe Profile)
+  , userBus :: BusRW (Maybe Profile)
+  }

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -19,6 +19,7 @@ import Data.Maybe (Maybe(..))
 import Data.Traversable (traverse_)
 import Effect (Effect)
 import Effect.Aff (Aff, launchAff_)
+import Effect.Aff.Bus as Bus
 import Effect.Ref as Ref
 import Halogen (liftAff, liftEffect)
 import Halogen as H
@@ -73,6 +74,10 @@ main = HA.runHalogenAff do
   -- since we don't yet have the user's profile.
   currentUser <- liftEffect $ Ref.new Nothing
 
+  -- We'll also create a new bus to broadcast updates when the value of the current user changes;
+  -- that allows all subscribed components to stay in sync about this value.
+  userBus <- liftEffect Bus.make
+
   -- We then get the landing page of the user. This will be passed as Input to the Router component,
   -- ensuring people aren't always redirected to the Home page, and that shared links for articles
   -- and other pages work as expected.
@@ -97,7 +102,7 @@ main = HA.runHalogenAff do
   -- fields. If our environment type ever changes, we'll get a compiler error here.
   let 
     environment :: Env
-    environment = { currentUser, baseUrl, logLevel }
+    environment = { currentUser, baseUrl, logLevel, userBus }
 
   -- With our app environment ready to go, we can prepare the router to run as our root component.
   --

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -10,9 +10,10 @@ import Affjax (printResponseFormatError, request)
 import Conduit.Api.Endpoint (Endpoint(..))
 import Conduit.Api.Request (BaseURL(..), RequestMethod(..), defaultRequest, readToken)
 import Conduit.Api.Utils (decodeAt)
-import Conduit.AppM (Env, LogLevel(..), runAppM)
+import Conduit.AppM (runAppM)
 import Conduit.Component.Router as Router
 import Conduit.Data.Route (routeCodec)
+import Conduit.Env (LogLevel(..), UserEnv, Env)
 import Data.Bifunctor (lmap)
 import Data.Either (hush)
 import Data.Maybe (Maybe(..))
@@ -59,9 +60,10 @@ main = HA.runHalogenAff do
   -- Our router component requires some information about its environment in order to run, so let's
   -- get that handled before we do anything else. 
   
-  -- Our environment is a small record type, `Env`, defined in the `Conduit.AppM` module. It 
-  -- requires three fields: the profile of the currently-authenticated user (if there is one), the 
-  -- base URL of the application, and the log level. 
+  -- Our environment is a small record type, `Env`, defined in the `Conduit.Env` module. It 
+  -- requires four fields: the profile of the currently-authenticated user (if there is one), the 
+  -- base URL of the application, the log level, and the channel used to broadcast changes in the
+  -- value of the current user.
 
   -- This is a small MVP, so we'll just define pure values like our base URL and log level as 
   -- constants. But it's also common to read configuration like this from the build environment.
@@ -96,7 +98,10 @@ main = HA.runHalogenAff do
   -- fields. If our environment type ever changes, we'll get a compiler error here.
   let 
     environment :: Env
-    environment = { currentUser, baseUrl, logLevel, userBus }
+    environment = { baseUrl, logLevel, userEnv }
+      where
+      userEnv :: UserEnv
+      userEnv = { currentUser, userBus }
 
   -- With our app environment ready to go, we can prepare the router to run as our root component.
   --

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -90,7 +90,6 @@ main = HA.runHalogenAff do
     res <- liftAff $ request $ defaultRequest baseUrl (Just token) requestOptions
     let u = decodeAt "user" =<< lmap printResponseFormatError res.body
     liftEffect $ Ref.write (hush u) currentUser
-    pure unit
 
   -- We now have the three pieces of information necessary to configure our app. Let's create
   -- a record that matches the `Env` type our application requires by filling in these three

--- a/src/Page/Home.purs
+++ b/src/Page/Home.purs
@@ -13,12 +13,12 @@ import Conduit.Component.HTML.Footer (footer)
 import Conduit.Component.HTML.Header (header)
 import Conduit.Component.HTML.Utils (css, maybeElem, whenElem)
 import Conduit.Component.Part.FavoriteButton (favorite, unfavorite)
-import Conduit.Component.Utils (loadUserEnv)
+import Conduit.Component.Utils (busEventSource)
 import Conduit.Data.Article (ArticleWithMetadata)
 import Conduit.Data.PaginatedArray (PaginatedArray)
 import Conduit.Data.Profile (Profile)
 import Conduit.Data.Route (Route(..))
-import Control.Monad.Reader (class MonadAsk)
+import Control.Monad.Reader (class MonadAsk, ask)
 import Data.Const (Const)
 import Data.Lens (Traversal')
 import Data.Lens.Index (ix)
@@ -29,6 +29,8 @@ import Data.Symbol (SProxy(..))
 import Effect.Aff.Bus (BusRW)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Ref (Ref)
+import Effect.Ref as Ref
+import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -95,8 +97,10 @@ component = H.mkComponent
 
   handleAction :: Action -> H.HalogenM State Action () Void m Unit
   handleAction = case _ of
-    Initialize ->
-      loadUserEnv HandleUserBus >>= case _ of
+    Initialize -> do
+      { currentUser, userBus } <- ask
+      _ <- H.subscribe (HandleUserBus <$> busEventSource userBus)
+      liftEffect (Ref.read currentUser) >>= case _ of
         Nothing -> 
           void $ H.fork $ handleAction $ LoadArticles noArticleParams
         profile -> do

--- a/src/Page/Home.purs
+++ b/src/Page/Home.purs
@@ -18,7 +18,8 @@ import Conduit.Data.Article (ArticleWithMetadata)
 import Conduit.Data.PaginatedArray (PaginatedArray)
 import Conduit.Data.Profile (Profile)
 import Conduit.Data.Route (Route(..))
-import Control.Monad.Reader (class MonadAsk, ask)
+import Conduit.Env (UserEnv)
+import Control.Monad.Reader (class MonadAsk, asks)
 import Data.Const (Const)
 import Data.Lens (Traversal')
 import Data.Lens.Index (ix)
@@ -26,9 +27,7 @@ import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..), isJust, isNothing)
 import Data.Monoid (guard)
 import Data.Symbol (SProxy(..))
-import Effect.Aff.Bus (BusRW)
 import Effect.Aff.Class (class MonadAff)
-import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Halogen (liftEffect)
 import Halogen as H
@@ -72,7 +71,7 @@ tabIsTag _ = false
 component
   :: forall m r
    . MonadAff m
-  => MonadAsk { currentUser :: Ref (Maybe Profile), userBus :: BusRW (Maybe Profile) | r } m
+  => MonadAsk { userEnv :: UserEnv | r } m
   => Navigate m
   => ManageTag m
   => ManageArticle m
@@ -98,7 +97,7 @@ component = H.mkComponent
   handleAction :: Action -> H.HalogenM State Action () Void m Unit
   handleAction = case _ of
     Initialize -> do
-      { currentUser, userBus } <- ask
+      { currentUser, userBus } <- asks _.userEnv
       _ <- H.subscribe (HandleUserBus <$> busEventSource userBus)
       void $ H.fork $ handleAction LoadTags
       liftEffect (Ref.read currentUser) >>= case _ of

--- a/src/Page/Home.purs
+++ b/src/Page/Home.purs
@@ -100,6 +100,7 @@ component = H.mkComponent
     Initialize -> do
       { currentUser, userBus } <- ask
       _ <- H.subscribe (HandleUserBus <$> busEventSource userBus)
+      void $ H.fork $ handleAction LoadTags
       liftEffect (Ref.read currentUser) >>= case _ of
         Nothing -> 
           void $ H.fork $ handleAction $ LoadArticles noArticleParams

--- a/src/Page/Login.purs
+++ b/src/Page/Login.purs
@@ -8,14 +8,13 @@ import Conduit.Api.Request (LoginFields)
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Resource.User (class ManageUser, loginUser)
 import Conduit.Component.HTML.Header (header)
-import Conduit.Component.HTML.Utils (css, safeHref)
+import Conduit.Component.HTML.Utils (css, safeHref, whenElem)
 import Conduit.Data.Email (Email)
 import Conduit.Data.Route (Route(..))
 import Conduit.Form.Field (submit)
 import Conduit.Form.Field as Field
 import Conduit.Form.Validation as V
 import Data.Const (Const)
-import Data.Foldable (traverse_)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Effect.Aff.Class (class MonadAff)
@@ -23,16 +22,6 @@ import Formless as F
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
-
--- | See the Formless tutorial to learn how to build your own forms: 
--- | https://github.com/thomashoneyman/purescript-halogen-formless
-
-newtype LoginForm r f = LoginForm (r
-  ( email :: f V.FormError String Email
-  , password :: f V.FormError String String
-  ))
-
-derive instance newtypeLoginForm :: Newtype (LoginForm r f) _
 
 data Action
   = HandleLoginForm LoginFields
@@ -46,7 +35,7 @@ type Input =
   { redirect :: Boolean }
 
 type ChildSlots = 
-  ( formless :: F.Slot LoginForm (Const Void) () LoginFields Unit )
+  ( formless :: F.Slot LoginForm FormQuery () LoginFields Unit )
 
 component 
   :: forall m
@@ -63,10 +52,15 @@ component = H.mkComponent
   handleAction :: Action -> H.HalogenM State Action ChildSlots Void m Unit
   handleAction = case _ of
     HandleLoginForm fields -> do
-      st <- H.get
       -- loginUser also handles broadcasting the user changes to subscribed components 
       -- so they receive the up-to-date value (see AppM and the `authenticate` function.)
-      loginUser fields >>= traverse_ (\_ -> when st.redirect $ navigate Home)
+      loginUser fields >>= case _ of
+        Nothing -> 
+          void $ H.query F._formless unit $ F.injQuery $ SetLoginError true unit
+        Just profile -> do
+          void $ H.query F._formless unit $ F.injQuery $ SetLoginError false unit
+          st <- H.get
+          when st.redirect (navigate Home)
 
   render :: State -> H.ComponentHTML Action ChildSlots m
   render _ =
@@ -97,39 +91,68 @@ component = H.mkComponent
                 ]
             ]
         ]
-    
-    formInput :: F.Input' LoginForm m
-    formInput =
-      { validators: LoginForm
-          { email: V.required >>> V.minLength 3 >>> V.emailFormat 
-          , password: V.required >>> V.minLength 2 >>> V.maxLength 20
-          }
-      , initialInputs: Nothing
+
+-- | See the Formless tutorial to learn how to build your own forms: 
+-- | https://github.com/thomashoneyman/purescript-halogen-formless
+
+newtype LoginForm r f = LoginForm (r
+  ( email :: f V.FormError String Email
+  , password :: f V.FormError String String
+  ))
+
+derive instance newtypeLoginForm :: Newtype (LoginForm r f) _
+
+-- We can extend our form to receive more queries than it supports by default. Here, we'll 
+-- set a login error from the parent.
+data FormQuery a
+  = SetLoginError Boolean a
+
+derive instance functorFormQuery :: Functor (FormQuery)
+
+formInput :: forall m. Monad m => F.Input LoginForm (loginError :: Boolean) m
+formInput =
+  { validators: LoginForm
+      { email: V.required >>> V.minLength 3 >>> V.emailFormat 
+      , password: V.required >>> V.minLength 2 >>> V.maxLength 20
       }
+  , initialInputs: Nothing
+  , loginError: false
+  }
 
-    formSpec :: F.Spec' LoginForm LoginFields m
-    formSpec = F.defaultSpec
-      { render = renderLogin 
-      , handleMessage = handleMessage
-      }
-      where
-      handleMessage = case _ of
-        F.Submitted outputs -> H.raise (F.unwrapOutputFields outputs)
-        _ -> pure unit
+formSpec :: forall m. F.Spec LoginForm (loginError :: Boolean) FormQuery Void () LoginFields m
+formSpec = F.defaultSpec
+  { render = renderLogin 
+  , handleMessage = handleMessage
+  , handleQuery = handleQuery
+  }
+  where
+  handleMessage = case _ of
+    F.Submitted outputs -> H.raise (F.unwrapOutputFields outputs)
+    _ -> pure unit
+  
+  handleQuery :: forall a. FormQuery a -> H.HalogenM _ _ _ _ _ (Maybe a)
+  handleQuery = case _ of
+    SetLoginError bool a -> do
+      H.modify_ _ { loginError = bool }
+      pure (Just a)
 
-      proxies = F.mkSProxies $ F.FormProxy :: _ LoginForm
+  proxies = F.mkSProxies $ F.FormProxy :: _ LoginForm
 
-      renderLogin { form } =
-        HH.form_
-          [ HH.fieldset_
-            [ Field.input proxies.email form 
-                [ HP.placeholder "Email"
-                , HP.type_ HP.InputEmail 
-                ]
-            , Field.input proxies.password form
-                [ HP.placeholder "Password"
-                , HP.type_ HP.InputPassword 
-                ]
-            , submit "Log in"
-            ]
+  renderLogin { form, loginError } =
+    HH.form_
+      [ whenElem loginError \_ -> 
+          HH.div       
+            [ css "error-messages" ]
+            [ HH.text "Email or password is invalid" ] 
+      , HH.fieldset_
+          [ Field.input proxies.email form 
+              [ HP.placeholder "Email"
+              , HP.type_ HP.InputEmail 
+              ]
+          , Field.input proxies.password form
+              [ HP.placeholder "Password"
+              , HP.type_ HP.InputPassword 
+              ]
+          , submit "Log in"
           ]
+      ]

--- a/src/Page/Login.purs
+++ b/src/Page/Login.purs
@@ -64,6 +64,8 @@ component = H.mkComponent
   handleAction = case _ of
     HandleLoginForm fields -> do
       st <- H.get
+      -- loginUser also handles broadcasting the user changes to subscribed components 
+      -- so they receive the up-to-date value (see AppM and the `authenticate` function.)
       loginUser fields >>= traverse_ (\_ -> when st.redirect $ navigate Home)
 
   render :: State -> H.ComponentHTML Action ChildSlots m

--- a/src/Page/Profile.purs
+++ b/src/Page/Profile.purs
@@ -21,6 +21,7 @@ import Conduit.Data.Profile (Profile, Author)
 import Conduit.Data.Route (Route(..))
 import Conduit.Data.Username (Username)
 import Conduit.Data.Username as Username
+import Conduit.Env (UserEnv)
 import Control.Monad.Reader (class MonadAsk, asks)
 import Data.Const (Const)
 import Data.Lens (Traversal')
@@ -30,7 +31,6 @@ import Data.Maybe (Maybe(..))
 import Data.Monoid (guard)
 import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
-import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Halogen as H
 import Halogen.HTML as HH
@@ -75,7 +75,7 @@ derive instance eqTab :: Eq Tab
 component
   :: forall m r
    . MonadAff m
-  => MonadAsk { currentUser :: Ref (Maybe Profile) | r } m
+  => MonadAsk { userEnv :: UserEnv | r } m
   => ManageUser m
   => ManageArticle m
   => H.Component HH.HTML (Const Void) Input Void m
@@ -103,7 +103,7 @@ component = H.mkComponent
   handleAction :: Action -> H.HalogenM State Action () Void m Unit
   handleAction = case _ of
     Initialize -> do
-      mbProfile <- H.liftEffect <<< Ref.read =<< asks _.currentUser
+      mbProfile <- H.liftEffect <<< Ref.read =<< asks _.userEnv.currentUser
       st <- H.modify _ { currentUser = mbProfile }
       void $ H.fork $ handleAction LoadAuthor
       void $ H.fork $ case st.tab of

--- a/src/Page/ViewArticle.purs
+++ b/src/Page/ViewArticle.purs
@@ -22,6 +22,7 @@ import Conduit.Data.PreciseDateTime as PDT
 import Conduit.Data.Profile (Profile, Relation(..), Author)
 import Conduit.Data.Route (Route(..))
 import Conduit.Data.Username as Username
+import Conduit.Env (UserEnv)
 import Control.Monad.Reader (class MonadAsk, asks)
 import Control.Parallel (parTraverse_)
 import Data.Const (Const)
@@ -32,7 +33,6 @@ import Data.Maybe (Maybe(..))
 import Data.Maybe as Maybe
 import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
-import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Halogen as H
 import Halogen.HTML as HH
@@ -75,7 +75,7 @@ component
   => ManageArticle m
   => ManageComment m
   => ManageUser m
-  => MonadAsk { currentUser :: Ref (Maybe Profile) | r } m
+  => MonadAsk { userEnv :: UserEnv | r } m
   => Navigate m
   => H.Component HH.HTML (Const Void) Input Void m
 component = H.mkComponent
@@ -100,7 +100,7 @@ component = H.mkComponent
   handleAction = case _ of
     Initialize -> do
       parTraverse_ H.fork [ handleAction GetArticle, handleAction GetComments ]
-      mbProfile <- H.liftEffect <<< Ref.read =<< asks _.currentUser
+      mbProfile <- H.liftEffect <<< Ref.read =<< asks _.userEnv.currentUser
       H.modify_ _ { currentUser = mbProfile } 
 
     GetArticle -> do


### PR DESCRIPTION
Encouraged by a discussion with @dogwith1eye in #24 and by two questions in the Halogen repository about handling global state ([#386](https://github.com/slamdata/purescript-halogen/issues/386) and [#494](https://github.com/slamdata/purescript-halogen/issues/494)), I decided to make a minor update to realworld. This PR introduces two main changes:

#### The global state now holds a mutable reference to the current user _and_ a bus that broadcasts the value of the current user anytime it changes. 

This is how most Halogen applications will handle mutable values in global state. With a `Ref` alone you know that any component can read the ref before using the value and will be up-to-date with the latest. However, if a component wants to cache the value in local state (for rendering, for example), then it needs some way to be notified that the value has changed so it can synchronize. This can be accomplished by using a many-to-many bus: a channel that can be written to from anywhere that has a reference, and which emits messages to many subscribers. Now, all components that copy the current user from global into local state can stay in sync by subscribing to updates from this bus.

#### The router state now holds on to the current user and a `Maybe` route and uses that information to gate access to particular pages at the router level. 

For example, logged-out users are not allowed to view the `Settings` or `Editor` pages, and logged-in users are not allowed to view the `Login` or `Register` pages. No individual component needs to deal with this anymore, which is more in keeping with what a production PureScript application would do. 

There's also the potential case where no route matched, which is now covered by a "Not Found" page. 

I also made a quality of life change: now, if you try to view a route only for logged-in users but are not logged in, you'll see the login component but you won't actually be redirected. That way, once you log in, you'll be on the page you expected to see.


### Additional

I have also made other small changes. First, I separated out the environment from `AppM` so it is its own module. Second, I updated the login form to report API errors, if they occur. It's a nice example of how you can extend Formless with extra queries and state as necessary.