### PR TITLE
Fix a few minor typos in documentation

### DIFF
--- a/src/Api/Request.purs
+++ b/src/Api/Request.purs
@@ -91,7 +91,7 @@ data RequestMethod
   | Delete
 
 -- | The base url and token are necessary to make a request, but are low-level implementation
--- | details.When actually using the API, we generally worry about which endpoint we'd like to 
+-- | details. When actually using the API, we generally worry about which endpoint we'd like to 
 -- | access and what request method we'd like to use.
 -- |
 -- | The `RequestOptions` type below relies on the `Endpoint` data type (which captures the possible

--- a/src/AppM.purs
+++ b/src/AppM.purs
@@ -61,7 +61,7 @@ import Type.Equality (class TypeEquals, from)
 -- |
 -- | This module implements a monad that can run all the abstract capabilities we've defined. This 
 -- | is our production monad. We'll implement the monad first, and then we'll provide concrete 
--- | instances for each of our abstract cayabilities.
+-- | instances for each of our abstract capabilities.
 
 -- | Let's start with some types necessary for the rest of the module.
 -- |
@@ -247,7 +247,7 @@ instance manageTagAppM :: ManageTag AppM where
       >>= decode (decodeAt "tags")
 
 -- | Our operations for managing comments
-instance manageCommentAppm :: ManageComment AppM where
+instance manageCommentAppM :: ManageComment AppM where
   getComments slug =
     mkRequest { endpoint: Comments slug, method: Get }
       >>= decodeWithUser decodeComments


### PR DESCRIPTION
Closes #30 by fixing a few typos in documentation and an instance name. These changes don't affect the meaning of the text but do keep things polished!