### PR TITLE
Update packages.dhall for new Formless version

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -22,7 +22,7 @@ let additions =
           , "profunctor-lenses"
           ]
           "https://github.com/thomashoneyman/purescript-halogen-formless.git"
-          "halogen-5"
+          "v1.0.0-rc.1"
       , slug =
           mkPackage
           [ "prelude"


### PR DESCRIPTION
Closes #40 by fixing the reference to Formless' `halogen-5` branch so it points at `v1.0.0-rc.1` instead. When Formless has a published 1.0 release I'll update the package set again to point at that.