### PR TITLE
Add higher-order component for connecting to global state

### DIFF
--- a/src/Component/HOC/Connect.purs
+++ b/src/Component/HOC/Connect.purs
@@ -1,0 +1,67 @@
+-- | This higher-order component exists to wrap other components which
+-- | need to connect to the user data in global application state and 
+-- | stay in sync with changes to that data.
+module Component.HOC.Connect where
+
+import Data.Symbol (SProxy(..))
+import Halogen as H
+import Halogen.HTML as HH
+
+data Action 
+  = Initialize
+  | HandleUserBus (Maybe Profile)
+
+type State input = 
+  { input :: input
+  , currentUser :: Maybe Profile
+  }
+
+type ChildSlots query output =
+  ( inner :: H.Slot query output Unit )
+
+_inner = SProxy :: SProxy "inner"
+
+-- | This component can re-use the query type and output type of its child
+-- | component because it has no queries or outputs of its own. That makes
+-- | it a transparent wrapper around the inner component.
+component
+  :: forall query output m r
+   . MonadAff m
+  => MonadAsk { userEnv :: UserEnv | r } m
+  => H.Component HH.HTML query input output m
+  -> H.Component HH.HTML query (State input) output m
+component innerComponent = 
+  H.mkComponent
+    { initialState: 
+        { input: _
+        , currentUser: Nothing 
+        }
+    , render
+    , eval: H.mkEval $ H.defaultEval
+        { handleAction = handleAction
+        , initialize = Just Initialize
+        }
+    }
+  where
+  handleAction = case _ of
+    -- On initialization we'll read the current value of the user in
+    -- state; we'll also subscribe to any updates so we can always 
+    -- stay in sync.
+    Initialize -> do
+      { currentUser, userBus } <- asks _.userEnv
+      _ <- H.subscribe (HandleUserBus <$> busEventSource userBus)
+      mbProfile <- liftEffect $ Ref.read currentUser
+      H.modify_ _ { currentUser = mbProfile }
+
+    -- When the user in global state changes, this event will occur
+    -- and we need to update our local state to stay in sync.
+    HandleUserBus mbProfile ->
+      H.modify_ _ { currentUser = mbProfile }
+
+    Bubble output ->
+      H.raise output
+
+  -- Here, we pass the inner component its input along with the current
+  -- user from the global state.
+  render state = 
+    HH.slot _inner unit innerComponent state (Just <<< Bubble)

--- a/src/Component/HOC/Connect.purs
+++ b/src/Component/HOC/Connect.purs
@@ -24,10 +24,8 @@ data Action output
   | HandleUserBus (Maybe Profile)
   | Emit output
 
-type State input = 
-  { currentUser :: Maybe Profile
-  , input :: input
-  }
+type WithCurrentUser r =
+  ( currentUser :: Maybe Profile | r )
 
 type ChildSlots query output =
   ( inner :: H.Slot query output Unit )
@@ -42,7 +40,7 @@ component
    . MonadAff m
   => MonadAsk { userEnv :: UserEnv | r } m
   => Row.Lacks "currentUser" input 
-  => H.Component HH.HTML query { currentUser :: Maybe Profile | input } output m
+  => H.Component HH.HTML query { | WithCurrentUser input } output m
   -> H.Component HH.HTML query { | input } output m
 component innerComponent = 
   H.mkComponent

--- a/src/Component/Router.purs
+++ b/src/Component/Router.purs
@@ -7,6 +7,7 @@ module Conduit.Component.Router where
 
 import Prelude
 
+import Component.HOC.Connect as Connect
 import Conduit.Capability.LogMessages (class LogMessages)
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Now (class Now)
@@ -135,10 +136,10 @@ component = H.mkComponent
         HH.slot (SProxy :: _ "settings") unit Settings.component unit absurd
           # authorize currentUser
       Editor -> 
-        HH.slot (SProxy :: _ "editor") unit Editor.component { slug: Nothing } absurd
+        HH.slot (SProxy :: _ "editor") unit (Connect.component Editor.component) { slug: Nothing } absurd
           # authorize currentUser
       EditArticle slug -> 
-        HH.slot (SProxy :: _ "editor") unit Editor.component { slug: Just slug } absurd
+        HH.slot (SProxy :: _ "editor") unit (Connect.component Editor.component) { slug: Just slug } absurd
           # authorize currentUser
       ViewArticle slug -> 
         HH.slot (SProxy :: _ "viewArticle") unit ViewArticle.component { slug } absurd

--- a/src/Component/Router.purs
+++ b/src/Component/Router.purs
@@ -7,6 +7,8 @@ module Conduit.Component.Router where
 
 import Prelude
 
+import Component.HOC.Connect (WithCurrentUser)
+import Component.HOC.Connect as Connect
 import Conduit.Capability.LogMessages (class LogMessages)
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Now (class Now)
@@ -14,7 +16,7 @@ import Conduit.Capability.Resource.Article (class ManageArticle)
 import Conduit.Capability.Resource.Comment (class ManageComment)
 import Conduit.Capability.Resource.Tag (class ManageTag)
 import Conduit.Capability.Resource.User (class ManageUser)
-import Conduit.Component.Utils (OpaqueSlot, busEventSource)
+import Conduit.Component.Utils (OpaqueSlot)
 import Conduit.Data.Profile (Profile)
 import Conduit.Data.Route (Route(..), routeCodec)
 import Conduit.Env (UserEnv)
@@ -26,13 +28,12 @@ import Conduit.Page.Profile as Profile
 import Conduit.Page.Register as Register
 import Conduit.Page.Settings as Settings
 import Conduit.Page.ViewArticle as ViewArticle
-import Control.Monad.Reader (class MonadAsk, asks)
+import Control.Monad.Reader (class MonadAsk)
 import Data.Either (hush)
 import Data.Foldable (elem)
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
-import Effect.Ref as Ref
 import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
@@ -49,7 +50,7 @@ data Query a
 
 data Action 
   = Initialize 
-  | HandleUserBus (Maybe Profile)
+  | Receive { | WithCurrentUser () }
 
 type ChildSlots = 
   ( home :: OpaqueSlot Unit
@@ -72,13 +73,14 @@ component
   => ManageArticle m
   => ManageComment m
   => ManageTag m
-  => H.Component HH.HTML Query Unit Void m
-component = H.mkComponent
-  { initialState: \_ -> { route: Nothing, currentUser: Nothing } 
+  => H.Component HH.HTML Query {} Void m
+component = Connect.component $ H.mkComponent
+  { initialState: \{ currentUser } -> { route: Nothing, currentUser } 
   , render
   , eval: H.mkEval $ H.defaultEval 
       { handleQuery = handleQuery 
       , handleAction = handleAction
+      , receive = Just <<< Receive
       , initialize = Just Initialize
       }
   }
@@ -86,19 +88,13 @@ component = H.mkComponent
   handleAction :: Action -> H.HalogenM State Action ChildSlots Void m Unit
   handleAction = case _ of
     Initialize -> do
-      -- first, we'll get the value of the current user and subscribe to updates any time the
-      -- value changes
-      { currentUser, userBus } <- asks _.userEnv
-      _ <- H.subscribe (HandleUserBus <$> busEventSource userBus)
-      mbProfile <- liftEffect (Ref.read currentUser) 
-      H.modify_ _ { currentUser = mbProfile }
-      -- then, we'll get the route the user landed on
+      -- first we'll get the route the user landed on
       initialRoute <- hush <<< (RD.parse routeCodec) <$> liftEffect getHash
-      -- and, finally, we'll navigate to the new route (also setting the hash)
+      -- then we'll navigate to the new route (also setting the hash)
       navigate $ fromMaybe Home initialRoute
     
-    HandleUserBus mbProfile -> do
-      H.modify_ _ { currentUser = mbProfile }
+    Receive { currentUser } ->
+      H.modify_ _ { currentUser = currentUser }
 
   handleQuery :: forall a. Query a -> H.HalogenM State Action ChildSlots Void m (Maybe a)
   handleQuery = case _ of
@@ -126,7 +122,7 @@ component = H.mkComponent
   render { route, currentUser } = case route of
     Just r -> case r of
       Home -> 
-        HH.slot (SProxy :: _ "home") unit Home.component unit absurd
+        HH.slot (SProxy :: _ "home") unit Home.component {} absurd
       Login -> 
         HH.slot (SProxy :: _ "login") unit Login.component { redirect: true } absurd
       Register -> 
@@ -135,8 +131,8 @@ component = H.mkComponent
         HH.slot (SProxy :: _ "settings") unit Settings.component unit absurd
           # authorize currentUser
       Editor -> 
-        authorize currentUser 
-          $ HH.slot (SProxy :: _ "editor") unit Editor.component { slug: Nothing } absurd
+        HH.slot (SProxy :: _ "editor") unit Editor.component { slug: Nothing } absurd
+          # authorize currentUser
       EditArticle slug -> 
         HH.slot (SProxy :: _ "editor") unit Editor.component { slug: Just slug } absurd
           # authorize currentUser

--- a/src/Component/Router.purs
+++ b/src/Component/Router.purs
@@ -7,7 +7,6 @@ module Conduit.Component.Router where
 
 import Prelude
 
-import Component.HOC.Connect as Connect
 import Conduit.Capability.LogMessages (class LogMessages)
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Now (class Now)
@@ -136,10 +135,10 @@ component = H.mkComponent
         HH.slot (SProxy :: _ "settings") unit Settings.component unit absurd
           # authorize currentUser
       Editor -> 
-        HH.slot (SProxy :: _ "editor") unit (Connect.component Editor.component) { slug: Nothing } absurd
-          # authorize currentUser
+        authorize currentUser 
+          $ HH.slot (SProxy :: _ "editor") unit Editor.component { slug: Nothing } absurd
       EditArticle slug -> 
-        HH.slot (SProxy :: _ "editor") unit (Connect.component Editor.component) { slug: Just slug } absurd
+        HH.slot (SProxy :: _ "editor") unit Editor.component { slug: Just slug } absurd
           # authorize currentUser
       ViewArticle slug -> 
         HH.slot (SProxy :: _ "viewArticle") unit ViewArticle.component { slug } absurd

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -122,7 +122,7 @@ main = HA.runHalogenAff do
   --
   -- Let's put it all together. With `hoist`, `runAppM`, our environment, and our router component,
   -- we can produce a proper root component for Halogen to run.  
-    rootComponent :: H.Component HH.HTML Router.Query Unit Void Aff
+    rootComponent :: H.Component HH.HTML Router.Query {} Void Aff
     rootComponent = H.hoist (runAppM environment) Router.component
 
   -- Now we have the two things we need to run a Halogen application: a reference to an HTML element
@@ -138,7 +138,7 @@ main = HA.runHalogenAff do
   -- Note: Since our root component is our router, the "queries" and "messages" above refer to the 
   -- `Query` and `Message` types defined in the `Conduit.Router` module. Only those queries and 
   -- messages can be used, or else you'll get a compiler error.
-  halogenIO <- runUI rootComponent unit body
+  halogenIO <- runUI rootComponent {} body
 
   -- Fantastic! Our app is running and we're almost done. All that's left is to notify the router
   -- any time the location changes in the URL. 

--- a/src/Page/Editor.purs
+++ b/src/Page/Editor.purs
@@ -5,7 +5,6 @@ module Conduit.Page.Editor where
 
 import Prelude
 
-import Component.HOC.Connect (WithCurrentUser)
 import Component.HOC.Connect as Connect
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Resource.Article (class ManageArticle, createArticle, getArticle, updateArticle)
@@ -14,6 +13,7 @@ import Conduit.Component.HTML.Utils (css, maybeElem)
 import Conduit.Component.TagInput (Tag(..))
 import Conduit.Component.TagInput as TagInput
 import Conduit.Data.Article (ArticleWithMetadata, Article)
+import Conduit.Data.Profile (Profile)
 import Conduit.Data.Route (Route(..))
 import Conduit.Env (UserEnv)
 import Conduit.Form.Field as Field
@@ -34,25 +34,20 @@ import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Network.RemoteData (RemoteData(..), fromMaybe, toMaybe)
 import Slug (Slug)
-import Type.Row (type (+))
 
 data Action
   = Initialize
-  | Receive { | InnerInput }
+  | Receive { slug :: Maybe Slug, currentUser :: Maybe Profile }
   | HandleEditor Article
 
 type State =
   { article :: RemoteData String ArticleWithMetadata
-  | InnerInput
+  , slug :: Maybe Slug
+  , currentUser :: Maybe Profile
   }
 
-type InnerInput =
-  ( WithCurrentUser
-  + Input
-  )
-
 type Input =
-  ( slug :: Maybe Slug )
+  { slug :: Maybe Slug }
 
 type ChildSlots =
   ( formless :: F.Slot EditorFields (Const Void) FormChildSlots Article Unit )
@@ -63,7 +58,7 @@ component
   => MonadAsk { userEnv :: UserEnv | r } m
   => Navigate m
   => ManageArticle m
-  => H.Component HH.HTML (Const Void) { | Input } Void m
+  => H.Component HH.HTML (Const Void) Input Void m
 component = Connect.component $ H.mkComponent
   -- due to the use of `Connect.component`, our input now also has `currentUser`
   -- in it, even though this component's only input is a slug.

--- a/src/Page/Editor.purs
+++ b/src/Page/Editor.purs
@@ -5,13 +5,13 @@ module Conduit.Page.Editor where
 
 import Prelude
 
+import Component.HOC.Connect as Connect
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Resource.Article (class ManageArticle, createArticle, getArticle, updateArticle)
 import Conduit.Component.HTML.Header (header)
 import Conduit.Component.HTML.Utils (css, maybeElem)
 import Conduit.Component.TagInput (Tag(..))
 import Conduit.Component.TagInput as TagInput
-import Conduit.Component.Utils (busEventSource)
 import Conduit.Data.Article (ArticleWithMetadata, Article)
 import Conduit.Data.Profile (Profile)
 import Conduit.Data.Route (Route(..))
@@ -19,7 +19,7 @@ import Conduit.Env (UserEnv)
 import Conduit.Form.Field as Field
 import Conduit.Form.Validation (errorToString)
 import Conduit.Form.Validation as V
-import Control.Monad.Reader (class MonadAsk, asks)
+import Control.Monad.Reader (class MonadAsk)
 import Data.Const (Const)
 import Data.Foldable (for_)
 import Data.Maybe (Maybe(..), isJust)
@@ -27,9 +27,7 @@ import Data.Newtype (class Newtype, unwrap)
 import Data.Set as Set
 import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
-import Effect.Ref as Ref
 import Formless as F
-import Halogen (liftEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -39,7 +37,6 @@ import Slug (Slug)
 
 data Action
   = Initialize
-  | HandleUserBus (Maybe Profile)
   | HandleEditor Article
 
 type State =
@@ -48,8 +45,13 @@ type State =
   , currentUser :: Maybe Profile
   }
 
+type InnerInput =
+  ( slug :: Maybe Slug )
+
 type Input =
-  { slug :: Maybe Slug }
+  { currentUser :: Maybe Profile
+  , slug :: Maybe Slug
+  }
 
 type ChildSlots =
   ( formless :: F.Slot EditorFields (Const Void) FormChildSlots Article Unit )
@@ -62,7 +64,7 @@ component
   => ManageArticle m
   => H.Component HH.HTML (Const Void) Input Void m
 component = H.mkComponent
-  { initialState: \{ slug } -> { article: NotAsked, currentUser: Nothing, slug }
+  { initialState: \{ currentUser, slug } -> { article: NotAsked, currentUser, slug }
   , render
   , eval: H.mkEval $ H.defaultEval
       { handleAction = handleAction
@@ -72,11 +74,8 @@ component = H.mkComponent
   where
   handleAction :: Action -> H.HalogenM State Action ChildSlots Void m Unit
   handleAction = case _ of
-    Initialize ->  do
-      { currentUser, userBus } <- asks _.userEnv
-      _ <- H.subscribe (HandleUserBus <$> busEventSource userBus)
-      mbProfile <- liftEffect $ Ref.read currentUser
-      st <- H.modify _ { currentUser = mbProfile }
+    Initialize -> do
+      st <- H.get
       for_ st.slug \slug -> do
         H.modify_ _ { article = Loading }
         mbArticle <- getArticle slug
@@ -88,16 +87,12 @@ component = H.mkComponent
           _ <- H.query F._formless unit $ F.asQuery $ F.loadForm newFields
           pure unit
 
-    HandleUserBus mbProfile ->
-      H.modify_ _ { currentUser = mbProfile }
-
     HandleEditor article -> do
       st <- H.get
       mbArticleWithMetadata <- case st.slug of
         Nothing -> createArticle article
         Just s -> updateArticle s article
-      let
-        slug = _.slug <$> mbArticleWithMetadata
+      let slug = _.slug <$> mbArticleWithMetadata
       H.modify_ _ { article = fromMaybe mbArticleWithMetadata, slug = slug }
       for_ slug (navigate <<< ViewArticle)
 

--- a/src/Page/Editor.purs
+++ b/src/Page/Editor.purs
@@ -49,9 +49,7 @@ type InnerInput =
   ( slug :: Maybe Slug )
 
 type Input =
-  { currentUser :: Maybe Profile
-  , slug :: Maybe Slug
-  }
+  { slug :: Maybe Slug }
 
 type ChildSlots =
   ( formless :: F.Slot EditorFields (Const Void) FormChildSlots Article Unit )
@@ -63,7 +61,9 @@ component
   => Navigate m
   => ManageArticle m
   => H.Component HH.HTML (Const Void) Input Void m
-component = H.mkComponent
+component = Connect.component $ H.mkComponent
+  -- due to the use of `Connect.component`, our input now also has `currentUser`
+  -- in it, even though this component's only input is a slug.
   { initialState: \{ currentUser, slug } -> { article: NotAsked, currentUser, slug }
   , render
   , eval: H.mkEval $ H.defaultEval

--- a/src/Page/Editor.purs
+++ b/src/Page/Editor.purs
@@ -85,7 +85,7 @@ component = Connect.component $ H.mkComponent
           let newFields = F.wrapInputFields { title, description, body, tagList: map Tag tagList }
           _ <- H.query F._formless unit $ F.asQuery $ F.loadForm newFields
           pure unit
-    
+
     Receive { currentUser } ->
       H.modify_ _ { currentUser = currentUser }
 

--- a/src/Page/Home.purs
+++ b/src/Page/Home.purs
@@ -4,7 +4,6 @@ module Conduit.Page.Home where
 
 import Prelude
 
-import Component.HOC.Connect (WithCurrentUser)
 import Component.HOC.Connect as Connect
 import Conduit.Api.Endpoint (ArticleParams, Pagination, noArticleParams)
 import Conduit.Capability.Navigate (class Navigate)
@@ -17,6 +16,7 @@ import Conduit.Component.HTML.Utils (css, maybeElem, whenElem)
 import Conduit.Component.Part.FavoriteButton (favorite, unfavorite)
 import Conduit.Data.Article (ArticleWithMetadata)
 import Conduit.Data.PaginatedArray (PaginatedArray)
+import Conduit.Data.Profile (Profile)
 import Conduit.Data.Route (Route(..))
 import Conduit.Env (UserEnv)
 import Control.Monad.Reader (class MonadAsk)
@@ -38,7 +38,7 @@ import Web.UIEvent.MouseEvent (MouseEvent, toEvent)
 
 data Action
   = Initialize
-  | Receive { | Input }
+  | Receive { currentUser :: Maybe Profile }
   | ShowTab Tab
   | LoadFeed Pagination
   | LoadArticles ArticleParams
@@ -52,10 +52,8 @@ type State =
   , articles :: RemoteData String (PaginatedArray ArticleWithMetadata)
   , tab :: Tab
   , page :: Int
-  | Input
+  , currentUser :: Maybe Profile
   }
-
-type Input = WithCurrentUser ()
 
 data Tab
   = Feed
@@ -86,7 +84,6 @@ component = Connect.component $ H.mkComponent
       }
   }
   where
-  initialState :: { | Input } -> State
   initialState { currentUser } =
     { tags: NotAsked
     , articles: NotAsked

--- a/src/Page/Home.purs
+++ b/src/Page/Home.purs
@@ -103,10 +103,10 @@ component = Connect.component $ H.mkComponent
         profile -> do
           void $ H.fork $ handleAction $ LoadFeed { limit: Just 20, offset: Nothing }
           H.modify_ _ { tab = Feed }
-    
+
     Receive { currentUser } ->
       H.modify_ _ { currentUser = currentUser }
-      
+
     LoadTags -> do
       H.modify_ _ { tags = Loading}
       tags <- getAllTags


### PR DESCRIPTION
## Rationale

Conduit has a global state which contains the currently logged in user via a mutable reference. That information is in global state because several components (the router, the home page, and the editor) need to know about the current user in order to function correctly. Those components need to take several actions to properly hook up to the global state:

1. On initialization, they must fetch the value of the current user from global state, and also fetch a reference to the bus which pushes updates out when that value changes
2. They must provide an action, typically `HandleUserBus`, which updates their state when the value of the current user changes
3. They must, on initialization, use the action to subscribe to updates in the value of the current user

This is all a bit tedious and largely irrelevant to the components other than having an always up-to-date reference to the current user. Ideally, we could just have that reference and not worry about the mechanics of getting it and updating it.

This PR introduces a new higher-order component, `Connect.component`, which takes care of all of this behind the scenes. With this change, components can remove all the steps I described. 

Instead, they now have `currentUser :: Maybe Profile` inserted into their input type and can use the ordinary `receive` function from Halogen to update their state when this value changes. Parent components can use the child components as usual, without even knowing that the higher order component is in place. As far as the parent is concerned the component has its old input; as far as the child is concerned, its input has `currentUser` inserted. Querying, messages, and so on all behave as usual.

## Other notes

This module could use some extra explanatory comments about higher-order components in Halogen, but I'm wary of stuffing it full of information not relevant for folks already versed in Halogen and who have used higher order components before.

This build has not been tested locally yet and will require that before merging.