### PR TITLE
Update to latest package set

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -2,8 +2,7 @@ let mkPackage =
       https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190725/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.5-20200103/packages.dhall sha256:0a6051982fb4eedb72fbe5ca4282259719b7b9b525a4dda60367f98079132f30
-
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200123/packages.dhall sha256:687bb9a2d38f2026a89772c47390d02939340b01e31aaa22de9247eadd64af05
 
 let overrides =
       { halogen = upstream.halogen // { version = "v5.0.0-rc.7" }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,6 +1,3 @@
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190725/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200123/packages.dhall sha256:687bb9a2d38f2026a89772c47390d02939340b01e31aaa22de9247eadd64af05
 
@@ -10,11 +7,17 @@ let overrides =
       }
 
 let additions =
-      { subcategory =
-          mkPackage
-            [ "prelude", "profunctor", "record" ]
-            "https://github.com/matthew-hilty/purescript-subcategory.git"
-            "v0.2.0"
+  { subcategory =
+      { dependencies =
+          [ "prelude"
+          , "profunctor"
+          , "record"
+          ]
+      , repo =
+          "https://github.com/matthew-hilty/purescript-subcategory.git"
+      , version =
+          "v0.2.0"
       }
+  }
 
 in  upstream // overrides // additions


### PR DESCRIPTION
Sorry to bombard you. I thought I'd gotten the latest package set in that previous PR, but it was the penultimate one, unfortunately.

I also built and ran with this set and verified that `subcategory` is not in the set.