### PR TITLE
Reload article when the slug changes

### DIFF
--- a/src/Page/Editor.purs
+++ b/src/Page/Editor.purs
@@ -86,8 +86,11 @@ component = Connect.component $ H.mkComponent
           _ <- H.query F._formless unit $ F.asQuery $ F.loadForm newFields
           pure unit
 
-    Receive { currentUser } ->
+    Receive { slug, currentUser } -> do
+      st <- H.get
       H.modify_ _ { currentUser = currentUser }
+      when (slug /= st.slug) do
+        handleAction Initialize
 
     HandleEditor article -> do
       st <- H.get

--- a/src/Page/Editor.purs
+++ b/src/Page/Editor.purs
@@ -87,8 +87,7 @@ component = Connect.component $ H.mkComponent
           pure unit
 
     Receive { slug, currentUser } -> do
-      st <- H.get
-      H.modify_ _ { currentUser = currentUser }
+      st <- H.modify _ { currentUser = currentUser }
       when (slug /= st.slug) do
         handleAction Initialize
 

--- a/src/Page/ViewArticle.purs
+++ b/src/Page/ViewArticle.purs
@@ -150,8 +150,10 @@ component = H.mkComponent
       H.modify_ _ { comments = fromMaybe comments }
 
     Receive { slug } -> do
-      H.modify_ _ { slug = slug }
-      handleAction Initialize
+      st <- H.get
+      when (st.slug /= slug) do
+        H.modify_ _ { slug = slug }
+        handleAction Initialize
 
   _author :: Traversal' State Author
   _author = _article <<< prop (SProxy :: SProxy "author")

--- a/src/Page/ViewArticle.purs
+++ b/src/Page/ViewArticle.purs
@@ -53,6 +53,7 @@ data Action
   | UnfavoriteArticle
   | DeleteArticle
   | DeleteComment CommentId
+  | Receive Input
 
 type State =
   { article :: RemoteData String ArticleWithMetadata
@@ -84,6 +85,7 @@ component = H.mkComponent
   , eval: H.mkEval $ H.defaultEval
       { handleAction = handleAction
       , initialize = Just Initialize
+      , receive = Just <<< Receive
       }
   }
   where
@@ -146,6 +148,10 @@ component = H.mkComponent
       deleteComment st.slug commentId
       comments <- getComments st.slug
       H.modify_ _ { comments = fromMaybe comments }
+
+    Receive { slug } -> do
+      H.modify_ _ { slug = slug }
+      handleAction Initialize
 
   _author :: Traversal' State Author
   _author = _article <<< prop (SProxy :: SProxy "author")


### PR DESCRIPTION
Fixes #52.

Previously, changing the slug on an article route without moving to a new route would not refresh the page contents. In the `ViewArticle` case, the component wasn't set up to listen to new input with a receiver and so it never used the new slug. In the `Editor` case, the component was listening to new input, but it wasn't using the new slug specifically.

In both cases it is not enough just to update the slug in state: if there is a new slug then we need to fetch the article associated with that slug. That's done by re-using the `Initialize` action in both components.

Thanks @VerySmallRoach and @cmdv for pointing this out!

Note: I have opted to guard the component to make sure the slug has actually changed before re-fetching data. However, this check is already done at the boundary of the application on route changes so it's not technically necessary. But I still like to add the check for extra peace of mind :)

Here's evidence of the fix:

![2020-02-14 00 46 44](https://user-images.githubusercontent.com/10245104/74515648-d35e8e00-4ec3-11ea-8cd1-24d3ac22b092.gif)
