### PR TITLE
Add receiver passthrough for connect component

### DIFF
--- a/src/Component/HOC/Connect.purs
+++ b/src/Component/HOC/Connect.purs
@@ -19,9 +19,10 @@ import Halogen.HTML as HH
 import Prim.Row as Row
 import Record as Record
 
-data Action output
+data Action input output
   = Initialize
   | HandleUserBus (Maybe Profile)
+  | Receive input
   | Emit output
 
 type WithCurrentUser r =
@@ -52,6 +53,7 @@ component innerComponent =
         { handleAction = handleAction
         , handleQuery = handleQuery
         , initialize = Just Initialize
+        , receive = Just <<< Receive
         }
     }
   where
@@ -69,6 +71,10 @@ component innerComponent =
     -- and we need to update our local state to stay in sync.
     HandleUserBus mbProfile ->
       H.modify_ _ { currentUser = mbProfile }
+    
+    Receive input -> do
+      { currentUser } <- H.get
+      H.put $ Record.insert (SProxy :: _ "currentUser") currentUser input
 
     Emit output ->
       H.raise output


### PR DESCRIPTION
This resolves an issue found by @cmdv in which input would not be passed through to a child component when using the `Connect` component. When I wrote the higher-order `Connect` component to automatically subscribe to a global state it wasn't necessary to pass any input through, but in the real world you will usually want this behavior.

This addresses the problem by adding a receiver to the higher-order component. When new input is received we inject the global state into it and update our state to pass through to the wrapped component. You can test this with the editor component by creating two articles, saving their URLs, and then navigating from editing the first to editing the second. The slug change is passed through to the wrapped editor component.