### PR TITLE
Initialize tag input from existing data in editor form

### DIFF
--- a/src/Page/Editor.purs
+++ b/src/Page/Editor.purs
@@ -179,12 +179,18 @@ formComponent mbArticle = F.component formInput $ F.defaultSpec
         [ title
         , description
         , body
-        , HH.slot (SProxy :: _ "tagInput") unit TagInput.component unit handler
-        , Field.submit $ if isJust mbArticle then "Commit changes" else "Publish"
+        , HH.slot (SProxy :: _ "tagInput") unit TagInput.component { tags } handler
+        , Field.submit do
+            if isJust mbArticle
+              then "Commit changes"
+              else "Publish"
         ]
       ]
     where
     handler = Just <<< F.injAction <<< HandleTagInput
+
+    tags =
+      Set.fromFoldable $ F.getInput proxies.tagList form
 
     title =
       Field.input proxies.title form


### PR DESCRIPTION
Fixes #54 by initializing the data in the tag input component using the loaded form state in the article editor.

From the conversation in #54 I've opted for the declarative method of providing tags via the tag input's input / receiver. In this application, the tag input's parent always knows the state of the set of selected tags, so I've opted to just pass that state through to the tag input directly.

In this case, the form state drives the contents of the tag input. The tags are first set from the form, which may have an empty set or may have data loaded when the form component initializes. Next, the user types some input and presses Enter, which causes the new tag to be added to the tag input's state and the TagAdded message to emit. The form picks up the new tag, updates the form state, and then the new list of tags is passed down to the tag input component. That component already has the updated state, so there are no further changes.

This causes a little more parent-child communication than existed before, but it also ensures that the tag input can be initialized from an existing form.

@mjepronk Do you mind verifying whether this fixes your issue? Thanks!