### PR TITLE
Add production bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dce-output
 dist
 *.lock
 *.map
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -34,13 +34,17 @@ all helper scripts for the project):
 yarn build
 ```
 
-Finally, bundle the JS and run a local server (defaults to [port 8080](http://127.0.0.1:8080), but if this port is already in use it will increment to 8081, etc.):
+You can bundle the JS for production (this requires installing Zephyr, [which you can get from its releases page](https://github.com/coot/zephyr/releases). Ensure it exists in your PATH by moving it to `usr/bin/local` or some equivalent).
+
+```sh
+yarn bundle
+```
+
+And, once bundled, you can run a local server to use Conduit (defaults to [port 8080](http://127.0.0.1:8080), but if this port is already in use it will increment to 8081, etc.):
 
 ```sh
 yarn serve
 ```
-
-You can also run `yarn bundle` to create a distribution-ready bundle of JavaScript without starting a server.
 
 ## Learning PureScript
 

--- a/assets/index.html
+++ b/assets/index.html
@@ -17,6 +17,6 @@
     <link rel="stylesheet" href="//demo.productionready.io/main.css" />
   </head>
   <body>
-    <script src="../dist/app.js"></script>
+    <script src="../index.js"></script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+var Main = require("./dce-output/Main");
+Main.main();

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "An exemplary real-world application demonstrating PureScript and the Halogen framework",
   "scripts": {
     "postinstall": "spago install",
-    "clean": "rm -rf node_modules output .spago dist/* *.lock",
+    "clean": "rm -rf node_modules output dce-output .spago dist/* *.lock .cache",
     "build": "spago build",
     "watch": "spago build --watch",
-    "bundle": "spago bundle-app --main Main --to dist/app.js && parcel build assets/index.html",
-    "serve": "yarn bundle && http-server dist",
-    "test": "spago test"
+    "serve": "http-server dist",
+    "test": "spago test",
+    "bundle:build": "spago build --purs-args '--codegen corefn'",
+    "bundle:dce": "zephyr -f Main.main",
+    "bundle:parcel": "parcel build assets/index.html --no-source-maps --experimental-scope-hoisting",
+    "bundle": "npm run bundle:build && npm run bundle:dce && npm run bundle:parcel"
   },
   "repository": {
     "type": "git",
@@ -29,11 +32,11 @@
   "devDependencies": {
     "parcel-bundler": "^1.12.4",
     "purescript": "^0.13.6",
-    "spago": "^0.13.1"
+    "spago": "^0.15.2"
   },
   "dependencies": {
     "decimal.js": "^10.2.0",
     "http-server": "^0.12.1",
-    "marked": "^0.8.0"
+    "marked": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
   },
   "homepage": "https://github.com/thomashoneyman/purescript-halogen-realworld#readme",
   "devDependencies": {
+    "http-server": "^0.12.1",
     "parcel-bundler": "^1.12.4",
     "purescript": "^0.13.6",
     "spago": "^0.15.2"
   },
   "dependencies": {
     "decimal.js": "^10.2.0",
-    "http-server": "^0.12.1",
     "marked": "^1.0.0"
   }
 }


### PR DESCRIPTION
In #58, @Disco-Dave asked about producing a production-optimized bundle for this application. 

This commit introduces Zephyr, a dead code elimination tool for PureScript. It also tweaks the Parcel bundle to point at an explicit `index.js` file and to perform some dead code elimination.

Prior to this change, we produced a bundle of about 640kb. With this change the bundle is now about 580kb, around a 10% drop. A quick test with `gzip -c <bundle>.js | wc -c` shows the gzipped size for this project is is about **117kb**.

According to the results in this article:
https://www.freecodecamp.org/news/a-realworld-comparison-of-front-end-frameworks-with-benchmarks-2019-update-4be0d3c78075/

the gzipped size puts this implementation around the midpoint of the real world implementations, smaller than React / Angular but larger than Elm / Vue.

Closes #58.