### PR TITLE
Update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
   },
   "homepage": "https://github.com/thomashoneyman/purescript-halogen-realworld#readme",
   "devDependencies": {
-    "http-server": "^0.12.1",
+    "http-server": "^0.12.3",
     "parcel-bundler": "^1.12.4",
     "purescript": "^0.13.6",
     "spago": "^0.15.2"
   },
   "dependencies": {
     "decimal.js": "^10.2.0",
-    "marked": "^1.0.0"
+    "marked": "^1.1.0"
   }
 }


### PR DESCRIPTION
Closes #61 by updating the NPM dependencies to reduce warnings on installation. It's been a while since I updated and the warnings were benign.