### PR TITLE
Upgrade package set & remove halogen override

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "http-server": "^0.12.3",
     "parcel-bundler": "^1.12.4",
-    "purescript": "^0.13.8",
+    "purescript": "^0.13.6",
     "spago": "^0.15.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "http-server": "^0.12.3",
     "parcel-bundler": "^1.12.4",
-    "purescript": "^0.13.6",
+    "purescript": "^0.13.8",
     "spago": "^0.15.2"
   },
   "dependencies": {

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,6 +1,8 @@
 let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200507/packages.dhall sha256:9c1e8951e721b79de1de551f31ecb5a339e82bbd43300eb5ccfb1bf8cf7bbd62
 
+let overrides = {=}
+
 let additions =
       { subcategory =
         { dependencies = [ "prelude", "profunctor", "record" ]
@@ -9,4 +11,4 @@ let additions =
         }
       }
 
-in  upstream // additions
+in  upstream // overrides // additions

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,23 +1,12 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200123/packages.dhall sha256:687bb9a2d38f2026a89772c47390d02939340b01e31aaa22de9247eadd64af05
-
-let overrides =
-      { halogen = upstream.halogen // { version = "v5.0.0-rc.7" }
-      , halogen-vdom = upstream.halogen-vdom // { version = "v6.1.0" }
-      }
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200507/packages.dhall sha256:9c1e8951e721b79de1de551f31ecb5a339e82bbd43300eb5ccfb1bf8cf7bbd62
 
 let additions =
-  { subcategory =
-      { dependencies =
-          [ "prelude"
-          , "profunctor"
-          , "record"
-          ]
-      , repo =
-          "https://github.com/matthew-hilty/purescript-subcategory.git"
-      , version =
-          "v0.2.0"
+      { subcategory =
+        { dependencies = [ "prelude", "profunctor", "record" ]
+        , repo = "https://github.com/matthew-hilty/purescript-subcategory.git"
+        , version = "v0.2.0"
+        }
       }
-  }
 
-in  upstream // overrides // additions
+in  upstream // additions


### PR DESCRIPTION
In this PR:

- ~Upgrade to purs 0.13.8~ Hold off until zephyr handles externs stored in binary format.
- Upgrade to the most recent package set (`psc-0.13.6-20200507`)
- Remove the halogen override in `packages.dhall`

`halogen v5.0.0-rc.9` and `halogen-vdom v6.1.3` are in the package set. These were previously set to `v5.0.0-rc.7` and `v6.1.0`, respectively, in the `overrides` section of `packages.dhall`.