### PR TITLE
HOC → HigherOrder for clarity

### DIFF
--- a/src/Component/HigherOrder/Connect.purs
+++ b/src/Component/HigherOrder/Connect.purs
@@ -1,7 +1,7 @@
 -- | This higher-order component exists to wrap other components which
 -- | need to connect to the user data in global application state and
 -- | stay in sync with changes to that data.
-module Component.HOC.Connect where
+module Component.HigherOrder.Connect where
 
 import Prelude
 

--- a/src/Component/Router.purs
+++ b/src/Component/Router.purs
@@ -7,8 +7,8 @@ module Conduit.Component.Router where
 
 import Prelude
 
-import Component.HOC.Connect (WithCurrentUser)
-import Component.HOC.Connect as Connect
+import Component.HigherOrder.Connect (WithCurrentUser)
+import Component.HigherOrder.Connect as Connect
 import Conduit.Capability.LogMessages (class LogMessages)
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Now (class Now)

--- a/src/Page/Editor.purs
+++ b/src/Page/Editor.purs
@@ -5,7 +5,7 @@ module Conduit.Page.Editor where
 
 import Prelude
 
-import Component.HOC.Connect as Connect
+import Component.HigherOrder.Connect as Connect
 import Conduit.Capability.Navigate (class Navigate, navigate)
 import Conduit.Capability.Resource.Article (class ManageArticle, createArticle, getArticle, updateArticle)
 import Conduit.Component.HTML.Header (header)

--- a/src/Page/Home.purs
+++ b/src/Page/Home.purs
@@ -4,7 +4,7 @@ module Conduit.Page.Home where
 
 import Prelude
 
-import Component.HOC.Connect as Connect
+import Component.HigherOrder.Connect as Connect
 import Conduit.Api.Endpoint (ArticleParams, Pagination, noArticleParams)
 import Conduit.Capability.Navigate (class Navigate)
 import Conduit.Capability.Resource.Article (class ManageArticle, getArticles, getCurrentUserFeed)


### PR DESCRIPTION
As an abbreviation, it takes a whole extra thinking step for users to discover or know what `HOC` stands for. I would argue that the couple of extra characters of `Component/HigherOrder` compared to `Component/HOC` is much clearer to newcomers (as well as veterans).