### PR TITLE
Update easy-purescript-nix to support the latest Purescript

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -11,8 +11,8 @@ let
   pursPkgs = import (pkgs.fetchFromGitHub {
     owner = "justinwoo";
     repo = "easy-purescript-nix";
-    rev = "7ff5a12af5750f94d0480059dba0ba6b82c6c452";
-    sha256 = "0af25dqhs13ii4mx9jjkx2pww4ddbs741vb5gfc5ckxb084d69fq";
+    rev = "fbbb27c1afd51d729939a6a2006e954dbd844846";
+    sha256 = "1kw9cqycrq456dipd5mq7c1ij6jl3d9ajlnba152db3qrw5wmrg0";
   }) { inherit pkgs; };
 
 in pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
Previously, following the README and doing “nix-shell” followed by “npm run install” yielded:

    [error] Oh noes! It looks like the PureScript version installed on your system is not compatible with the package-set you're using.

    installed `purs` version:    0.13.8
    minimum package-set version: 0.14.0

This simply updates easy-purescript-nix to the latest version, allowing Nix users to build the project again.