### PR TITLE
Improvements/apple m1 related changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4187,25 +4187,16 @@
       "dev": true
     },
     "lmdb-store": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/lmdb-store/-/lmdb-store-1.6.5.tgz",
-      "integrity": "sha512-FqGv8TI16RfSAO8668UHTmKsFrw70VUpfWNmAOaExDrslcnJDTpCfuztWYFwpv/U/N2LvwYUInVZ3sVZUxaJGw==",
+      "version": "1.6.14",
+      "resolved": "https://nexus.tools.rezdy.com/repository/rc-npm-group/lmdb-store/-/lmdb-store-1.6.14.tgz",
+      "integrity": "sha512-4woZfvfgolMEngjoMJrwePjdLotr3QKGJsDWURlJmKBed5JtE00IfAKo7ryPowl4ksGcs21pcdLkwrPnKomIuA==",
       "dev": true,
       "requires": {
-        "mkdirp": "^1.0.4",
-        "msgpackr": "^1.3.7",
+        "msgpackr": "^1.5.0",
         "nan": "^2.14.2",
         "node-gyp-build": "^4.2.3",
-        "ordered-binary": "^0.2.3",
+        "ordered-binary": "^1.0.0",
         "weak-lru-cache": "^1.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        }
       }
     },
     "loader-utils": {
@@ -4541,19 +4532,18 @@
       "dev": true
     },
     "msgpackr": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.3.10.tgz",
-      "integrity": "sha512-UBIFb77RCA4tyABjQe0HypC59/gbwU41BPIW3KHj2NNyZQpfLLZWdvo1NTEvefUm4W+ivVABel/ZAQBd223zaA==",
+      "version": "1.5.1",
+      "resolved": "https://nexus.tools.rezdy.com/repository/rc-npm-group/msgpackr/-/msgpackr-1.5.1.tgz",
+      "integrity": "sha512-I1CXFG8BYYSeIhtDlHpUVMsdDiyvP9JAh1d9QoBnkPx3ETPeH/1lR14hweM9GETs09wCWlaOyhtXxIc9boxAAA==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "msgpackr-extract": "^1.0.13"
+        "msgpackr-extract": "^1.0.14"
       }
     },
     "msgpackr-extract": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.0.13.tgz",
-      "integrity": "sha512-JlQPllMLETiuQ5Vv3IAz+4uOpd1GZPOoCHv9P5ka5P5gkTssm/ejv0WwS4xAfB9B3vDwrExRwuU8v3HRQtJk2Q==",
+      "version": "1.0.15",
+      "resolved": "https://nexus.tools.rezdy.com/repository/rc-npm-group/msgpackr-extract/-/msgpackr-extract-1.0.15.tgz",
+      "integrity": "sha512-vgJgzFva0/4/mt84wXf3CRCDPHKqiqk5t7/kVSjk/V2IvwSjoStHhxyq/b2+VrWcch3sxiNQOJEWXgI86Fm7AQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4819,9 +4809,9 @@
       }
     },
     "ordered-binary": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-0.2.3.tgz",
-      "integrity": "sha512-5kFq2MEgVpV32YMVW8q74h1pV7xowy92J9bdHGSty+4mD/pKzNX38oJLE424k6qrLMq04U7+eopcQKNpVlupDA==",
+      "version": "1.1.3",
+      "resolved": "https://nexus.tools.rezdy.com/repository/rc-npm-group/ordered-binary/-/ordered-binary-1.1.3.tgz",
+      "integrity": "sha512-tDTls+KllrZKJrqRXUYJtIcWIyoQycP7cVN7kzNNnhHKF2bMKHflcAQK+pF2Eb1iVaQodHxqZQr0yv4HWLGBhQ==",
       "dev": true
     },
     "os-browserify": {
@@ -7124,9 +7114,9 @@
       }
     },
     "weak-lru-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.0.0.tgz",
-      "integrity": "sha512-135bPugHHIJLNx20guHgk4etZAbd7nou34NQfdKkJPgMuC3Oqn4cT6f7ORVvnud9oEyXJVJXPcTFsUvttGm5xg==",
+      "version": "1.1.3",
+      "resolved": "https://nexus.tools.rezdy.com/repository/rc-npm-group/weak-lru-cache/-/weak-lru-cache-1.1.3.tgz",
+      "integrity": "sha512-5LDIv+sr6uzT94Hhcq7Qv7gt3jxol4iMWUqOgJSLYbB5oO7bTSMqIBtKsytm8N2BufYOdJw86/qu+SDfbo/wKQ==",
       "dev": true
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "http-server": "^13.0.0",
+    "lmdb-store": "^1.6.14",
     "parcel": "^2.0.0-rc.0",
     "purescript-psa": "^0.8.2",
     "purs-tidy": "^0.1.1"

--- a/shell.nix
+++ b/shell.nix
@@ -21,5 +21,8 @@ in pkgs.stdenv.mkDerivation {
     pursPkgs.spago
     pursPkgs.zephyr
     pkgs.nodejs-14_x
-  ];
+  ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+    Cocoa
+    CoreServices
+  ]);
 }


### PR DESCRIPTION
I tried to run the project on a MacBook Air M1 and had some issues. 

I had to add two macOS related dependencies in order to `npm install` to go through without any issue.
Without it would fail on a `node-gyp rebuild`.

Then I had to add `lmdb-store` otherwise `parcel` would fail on a lmdb error stating that there were no binary / client.

