### PR TITLE
Moved to Nix Flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ You can enter a development shell with all non-JavaScript dependencies via Nix:
 $ nix-shell
 ```
 
+Or with Nix Flakes:
+
+```console
+$ nix develop
+```
+
+Or automatic shell support via [direnv](https://github.com/direnv/direnv) with an `.envrc` file in your root:
+
+```bash
+if type nix &>/dev/null; then
+  # https://github.com/nix-community/nix-direnv
+  if nix flake metadata &>/dev/null; then
+    use flake
+  else
+    use nix
+  fi
+fi
+```
+
 > Alternately, you can install `purescript`, `spago`, `purs-tidy`, `purescript-psa`, and the PureScript language server from NPM.
 
 Next, install JavaScript dependencies:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "easy-purescript-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1651400038,
+        "narHash": "sha256-bwbpXSTD8Hf7tlCXfZuLfo2QivvX1ZDJ1PijXXRTo3Q=",
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "rev": "0ad5775c1e80cdd952527db2da969982e39ff592",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "rev": "0ad5775c1e80cdd952527db2da969982e39ff592",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1652020977,
+        "narHash": "sha256-9hDlNbrxzD/pLlXmoQ6gzxbYiSAKrj7uHYUWNByLFlI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3c5ae9be1f18c790ea890ef8decbd0946c0b4c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "easy-purescript-nix": "easy-purescript-nix",
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -13,7 +13,6 @@
       "original": {
         "owner": "justinwoo",
         "repo": "easy-purescript-nix",
-        "rev": "0ad5775c1e80cdd952527db2da969982e39ff592",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "RealWorld spec in the PureScript Halogen framework";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+    easy-purescript-nix = {
+      # when it’s time for v0.15.x, rev should be removed
+      url =
+        "github:justinwoo/easy-purescript-nix?rev=0ad5775c1e80cdd952527db2da969982e39ff592";
+      flake = false;
+    };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, easy-purescript-nix, ... }@inputs:
+    let
+      name = "halogen-realworld";
+
+      supportedSystems = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in
+    {
+      devShell = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+
+          easy-ps = import easy-purescript-nix { inherit pkgs; };
+        in
+        pkgs.mkShell {
+          inherit name;
+          buildInputs = (with pkgs; [
+            nodejs-16_x
+            nixpkgs-fmt
+          ]) ++ (with easy-ps; [
+            purs
+            purs-tidy
+            psa
+            spago
+            purescript-language-server
+          ]) ++ (pkgs.lib.optionals (system == "aarch64-darwin")
+            (with pkgs.darwin.apple_sdk.framework; [
+              Cocoa
+              CoreServices
+            ]));
+        });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
     easy-purescript-nix = {
-      # when it’s time for v0.15.x, rev should be removed
-      url =
-        "github:justinwoo/easy-purescript-nix?rev=0ad5775c1e80cdd952527db2da969982e39ff592";
+      url = "github:justinwoo/easy-purescript-nix";
       flake = false;
     };
     flake-compat = {
@@ -19,7 +17,11 @@
     let
       name = "halogen-realworld";
 
-      supportedSystems = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
+      supportedSystems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
 
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
     in

--- a/shell.nix
+++ b/shell.nix
@@ -1,34 +1,10 @@
-let
-  pkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/21.11.tar.gz";
-  }) { };
-
-  # To update to a newer version of easy-purescript-nix, run:
-  # nix-prefetch-git https://github.com/justinwoo/easy-purescript-nix
-  #
-  # Then, copy the resulting rev and sha256 here.
-  pursPkgs = import (pkgs.fetchFromGitHub {
-    owner = "justinwoo";
-    repo = "easy-purescript-nix";
-    rev = "0ad5775c1e80cdd952527db2da969982e39ff592";
-    sha256 = "0x53ads5v8zqsk4r1mfpzf5913byifdpv5shnvxpgw634ifyj1kg";
-  }) { inherit pkgs; };
-
-in pkgs.mkShell {
-  name = "halogen-realworld";
-  buildInputs = [
-    pursPkgs.purs
-    pursPkgs.purs-tidy
-    pursPkgs.psa
-    pursPkgs.spago
-    pursPkgs.purescript-language-server
-
-    pkgs.nodejs-16_x
-    pkgs.nixfmt
-  ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
-    (with pkgs.darwin.apple_sdk.frameworks; [
-      # Apple M1
-      Cocoa
-      CoreServices
-    ]);
-}
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
Flakes are now in stable and the writing is on the wall that they are the way forward. It's a standardize API that offers faster shelling and is easier to update `nix flake update` instead of fussing about the `nixpkgs` Git repository, finding a commit hash, and then getting it's sha256 hash. The approach in this merge request offers backwards compatibility with the Flake-skeptical and older systems via `flake-compat`.

What needs testing: anything related to `darwin`. I don't have access to any of those types of machines.

---

Opinionated fix: move to [`nixpkgs-fmt`](https://github.com/nix-community/nixpkgs-fmt) over `nixfmt`. Like my gripes with `prettier`, `nixfmt` moves your code around too much to achieve its opinionated goals which causes unnecessary merge conflicts. String now needs one extra character? Better break all the lines apart and make a massive diff vs. `nixpkgs-fmt` whose goals are better for maintainability than aesthetics. One could easily compare this to moving from `purescript-tidy` from `purty` (though sadly no config file).