### PR TITLE
Fix flake for aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
             spago
             purescript-language-server
           ]) ++ (pkgs.lib.optionals (system == "aarch64-darwin")
-            (with pkgs.darwin.apple_sdk.framework; [
+            (with pkgs.darwin.apple_sdk.frameworks; [
               Cocoa
               CoreServices
             ]));


### PR DESCRIPTION
The flake is broken when running on M1. `pkgs.darwin.apple_sdk.framework` yield an unknown attribute error, the fix was prompted by the error message itself suggesting to change it to `frameworks`, hence the fix :)