### PR TITLE
Fix #118: npm run serve shows an empty page

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -9,6 +9,6 @@
     <link rel="stylesheet" href="//demo.productionready.io/main.css" />
   </head>
   <body>
-    <script src="./main.js"></script>
+    <script src="./index.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "spago build",
     "test": "spago test",
     "serve": "spago build && esbuild --bundle index.js --servedir=dist",
-    "bundle": "spago -x spago.production.dhall build && purs-backend-es bundle-app --main Main --minify --no-build --to dist/main.js"
+    "bundle": "spago -x spago.production.dhall build && purs-backend-es bundle-app --main Main --minify --no-build --to dist/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Renamed the output to index.js in the html and package.json.

Tested with npm run server as well as with the finished bundle and an external web server.